### PR TITLE
Pr/2437 shutdown

### DIFF
--- a/libretroshare/src/pqi/rstcpsocket.cc
+++ b/libretroshare/src/pqi/rstcpsocket.cc
@@ -84,7 +84,7 @@ RsThreadedTcpSocket::RsThreadedTcpSocket() : RsTcpSocket()
 }
 void RsThreadedTcpSocket::run()
 {
-    while(connectionState() == CONNECTED)
+    while(!shouldStop() && connectionState() == CONNECTED)
     {
         tick();
         std::this_thread::sleep_for(std::chrono::milliseconds(200));

--- a/libretroshare/src/retroshare/rstor.h
+++ b/libretroshare/src/retroshare/rstor.h
@@ -142,6 +142,12 @@ public:
     static bool start();
 
     /*!
+     * \brief stop
+     * 			Stop the Tor management threads.
+     */
+    static void stop();
+
+    /*!
      * \brief getHiddenServiceInfo
      * 			Gets information about the hidden service setup by RS to run.
      * \param service_id

--- a/libretroshare/src/tor/TorControl.cpp
+++ b/libretroshare/src/tor/TorControl.cpp
@@ -46,8 +46,6 @@
 #include "StrUtil.h"
 #include "PendingOperation.h"
 
-Tor::TorControl *torControl = 0;
-
 class nullstream: public std::ostream {};
 
 static std::ostream& torctrldebug()

--- a/libretroshare/src/tor/TorControl.cpp
+++ b/libretroshare/src/tor/TorControl.cpp
@@ -70,6 +70,11 @@ TorControl::TorControl()
     mSocket = new TorControlSocket(this);
 }
 
+TorControl::~TorControl()
+{
+    delete(mSocket);
+}
+
 static RsTorConnectivityStatus torConnectivityStatus(Tor::TorControl::Status t)
 {
     switch(t)

--- a/libretroshare/src/tor/TorControl.h
+++ b/libretroshare/src/tor/TorControl.h
@@ -68,6 +68,7 @@ public:
     };
 
     explicit TorControl();
+    virtual ~TorControl();
 
     /* Information */
     Status status() const;

--- a/libretroshare/src/tor/TorControl.h
+++ b/libretroshare/src/tor/TorControl.h
@@ -149,5 +149,3 @@ private:
 };
 
 }
-
-extern Tor::TorControl *torControl;

--- a/libretroshare/src/tor/TorManager.cpp
+++ b/libretroshare/src/tor/TorManager.cpp
@@ -95,6 +95,11 @@ TorManager::TorManager()
 {
 }
 
+TorManager::~TorManager()
+{
+    delete(d);
+}
+
 TorManagerPrivate::TorManagerPrivate(TorManager *parent)
     : q(parent)
     , process(0)

--- a/libretroshare/src/tor/TorManager.cpp
+++ b/libretroshare/src/tor/TorManager.cpp
@@ -71,6 +71,7 @@ public:
 	HiddenService *hiddenService ;
 
     explicit TorManagerPrivate(TorManager *parent = 0);
+    virtual ~TorManagerPrivate();
 
     std::string torExecutablePath() const;
     bool createDataDir(const std::string &path);
@@ -102,6 +103,11 @@ TorManagerPrivate::TorManagerPrivate(TorManager *parent)
     , hiddenService(NULL)
 {
     control->set_statusChanged_callback([this](int new_status,int /*old_status*/) { controlStatusChanged(new_status); });
+}
+
+TorManagerPrivate::~TorManagerPrivate()
+{
+    delete(control);
 }
 
 TorManager *TorManager::instance()

--- a/libretroshare/src/tor/TorManager.cpp
+++ b/libretroshare/src/tor/TorManager.cpp
@@ -53,6 +53,8 @@
 
 using namespace Tor;
 
+static TorManager *rsTor = nullptr;
+
 namespace Tor
 {
 
@@ -840,6 +842,17 @@ bool RsTor::start()
     return instance()->startTorManager();
 }
 
+void RsTor::stop()
+{
+    if (rsTor) {
+        if (rsTor->isRunning()) {
+            rsTor->fullstop();
+        }
+        delete(rsTor);
+        rsTor= nullptr;
+    }
+}
+
 void RsTor::setTorDataDirectory(const std::string& dir)
 {
     instance()->setTorDataDirectory(dir);
@@ -854,8 +867,6 @@ TorManager *RsTor::instance()
 #if !defined(_WIN32) && !defined(__MINGW32__)
     assert(getpid() == syscall(SYS_gettid));// make sure we're not in a thread
 #endif
-
-    static TorManager *rsTor = nullptr;
 
     if(rsTor == nullptr)
         rsTor = new TorManager;

--- a/libretroshare/src/tor/TorManager.cpp
+++ b/libretroshare/src/tor/TorManager.cpp
@@ -462,7 +462,7 @@ void TorManager::run()
         std::this_thread::sleep_for(std::chrono::milliseconds(50));
     }
 
-    d->control->shutdown();
+    d->control->shutdownSync();
     d->process->stop();
 
     if(rsEvents)

--- a/libretroshare/src/tor/TorManager.h
+++ b/libretroshare/src/tor/TorManager.h
@@ -51,6 +51,7 @@ class TorManager : public HiddenServiceClient, public RsThread, public RsTor
 {
 public:
     static TorManager *instance();
+    virtual ~TorManager();
 
     TorProcess *process();
     TorControl *control();

--- a/retroshare-gui/src/TorControl/TorControlWindow.cpp
+++ b/retroshare-gui/src/TorControl/TorControlWindow.cpp
@@ -51,6 +51,11 @@ TorControlDialog::TorControlDialog(QWidget *)
         adjustSize();
 }
 
+TorControlDialog::~TorControlDialog()
+{
+    rsEvents->unregisterEventsHandler(mEventHandlerId);
+}
+
 void TorControlDialog::handleEvent_main_thread(std::shared_ptr<const RsEvent> event)
 {
     if(event->mType != RsEventType::TOR_MANAGER) return;

--- a/retroshare-gui/src/TorControl/TorControlWindow.h
+++ b/retroshare-gui/src/TorControl/TorControlWindow.h
@@ -15,6 +15,7 @@ class TorControlDialog: public QWidget, public Ui::TorControlDialog
 
 public:
     TorControlDialog(QWidget *parent =NULL);
+    virtual ~TorControlDialog();
 
 	enum TorStatus {
 		TOR_STATUS_UNKNOWN = 0x00,

--- a/retroshare-gui/src/main.cpp
+++ b/retroshare-gui/src/main.cpp
@@ -591,6 +591,10 @@ feenableexcept(FE_INVALID | FE_DIVBYZERO);
 	RsGxsUpdateBroadcast::cleanup();
 #endif
 
+	if (is_auto_tor) {
+		RsTor::stop();
+	}
+
 	RsControl::instance()->rsGlobalShutDown();
 
 	delete(soundManager);


### PR DESCRIPTION
Based on my PR 2437 #32 I added two more commits to shutdown the tor management threads.
- Use shutdownSync instead of shutdown in TorManager::run to stop tor
- Added shutdown of tor management threads
I am not sure with RsTor::stop()